### PR TITLE
No interpolation for non-continuous fields

### DIFF
--- a/dwdweather.js
+++ b/dwdweather.js
@@ -113,6 +113,9 @@ module.exports = function(RED) {
         } else if (idx==0) {
             // all predictions in file are for the future => return first one
             return weatherForecast[mosmixStation][attribute][0];
+        } else if (Number.isNaN( weatherForecast[mosmixStation][attribute][idx-1] )) {
+            // non-continuous field, so no interpolation possible
+            return weatherForecast[mosmixStation][attribute][idx];
         } else {
             // linear interpolation of current temperature
             var share = (forecastDate.getTime() - weatherForecast[mosmixStation].times[idx-1].getTime()) / (weatherForecast[mosmixStation].times[idx].getTime() - weatherForecast[mosmixStation].times[idx-1].getTime());

--- a/dwdweather.js
+++ b/dwdweather.js
@@ -254,9 +254,6 @@ module.exports = function(RED) {
             // initWeatherForecast(node.mosmixStation);
         });
 
-        node.emit("input",{
-            payload: {}
-        });
     }
 
     RED.nodes.registerType("dwdweather",DwdWeatherQueryNode);


### PR DESCRIPTION
This PR solves https://github.com/c5te1n/node-red-contrib-dwd-local-weather/issues/12

Some forecast fields are non-continuous, i.e. do not contain valid data for each forecast time point.
Instead they just contain "-".
Number.parseFloat() will parse that as NaN, causing the interpolation to fail and return NaN as well.
Except for files that are fully in the future, nothing but NaN will be returned, because interpolation will always fail.

With this fix, the node first checks the previous forecast for NaN and only interpolates if it's a valid number.
Resulting behavior:
- Both values are numbers: Normal interpolation.
- First value is NaN: Take second value without interpolation.
	Obviously, if the second the value is NaN, too, the result will still be NaN.
- Second value is NaN: Result is also NaN.