### PR TITLE
Do not emit unrequested message on deploy.

### DIFF
--- a/dwdweather.js
+++ b/dwdweather.js
@@ -251,9 +251,6 @@ module.exports = function(RED) {
             // initWeatherForecast(node.mosmixStation);
         });
 
-        node.emit("input",{
-            payload: {}
-        });
     }
 
     RED.nodes.registerType("dwdweather",DwdWeatherQueryNode);


### PR DESCRIPTION
The last lines in the code will cause an unrequested message to be emitted.

I don't think that's expected node-red behavior. At least no other node I encountered did this.
Also, in my case it caused problems, because I request weather data for a variable time in the future and the unrequested message fetches the forecast for a wrong time.