### PR TITLE
fix broken link to mosmix element list

### DIFF
--- a/dwdweather.html
+++ b/dwdweather.html
@@ -43,7 +43,7 @@
         <input type="text" id="node-input-additionalFields" placeholder="additionalFields">
     </div>
     <div class="form-row" style="padding-left: 10px">
-        <span data-i18n="dwdweather.description.additionalFields"></span><a href="https://www.dwd.de/DE/leistungen/opendata/help/schluessel_datenformate/kml/mosmix_elemente_pdf.pdf" target="_blank"><span data-i18n="dwdweather.description.additionalFieldsLinkText"></span></a>
+        <span data-i18n="dwdweather.description.additionalFields"></span><a href="https://www.dwd.de/DE/leistungen/opendata/help/schluessel_datenformate/kml/mosmix_elemente_xls.html" target="_blank"><span data-i18n="dwdweather.description.additionalFieldsLinkText"></span></a>
     </div>
     <div class="form-row">
         <label for="node-input-name"><i class="icon-tag"></i> <span data-i18n="dwdweather.label.name"></span></label>


### PR DESCRIPTION
The link to the mosmix elements is broken. I believe I found a replacement.