### PR TITLE
make the message which is deployed on start optional

### DIFF
--- a/dwdweather.html
+++ b/dwdweather.html
@@ -7,6 +7,7 @@
             mosmixStation: { "value": null, "required": true, "validate": RED.validators.regex(/[A-Z0-9]{3,5}/) },
             lookAheadHours: { "value": "0", "required": true, "validate": RED.validators.number() },
             additionalFields: { "value": "" },
+            omitMessageOnStart: { "value": true },
             repeat: { "value": "0", "validate":function(v) { return (v>=0); } },
             topic: { "value": "" },
         },
@@ -33,6 +34,10 @@
     </div>
     <div class="form-row" style="padding-left: 10px">
         <span data-i18n="dwdweather.description.lookAheadHours"></span>
+    </div>
+    <div class="form-row">
+        <label for="node-input-omitMessageOnStart"><i class="fa fa-crosshairs"></i> <span data-i18n="dwdweather.label.omitMessageOnStart"></span></label>
+        <input type="checkbox" id="node-input-omitMessageOnStart" placeholder="omitMessageOnStart">
     </div>
     <div class="form-row">
         <label for="node-input-repeat"><i class="icon-repeat"></i> <span data-i18n="dwdweather.label.repeat"></span></label>

--- a/dwdweather.js
+++ b/dwdweather.js
@@ -297,9 +297,11 @@ module.exports = function(RED) {
             // initWeatherForecast(node.mosmixStation);
         });
 
-        node.emit("input",{
-            payload: {}
-        });
+        if (!config.omitMessageOnStart) {
+            node.emit("input", {
+                payload: {}
+            });
+        }
     }
 
     RED.nodes.registerType("dwdweather",DwdWeatherQueryNode);

--- a/locales/en-US/dwdweather.json
+++ b/locales/en-US/dwdweather.json
@@ -2,6 +2,7 @@
 	"dwdweather": {
 		"label": {
 			"name": "Name",
+			"omitMessageOnStart": "Omit message on start",
 			"repeat": "Repeat",
 			"mosmixStation": "MOSMIX Station",
 			"lookAheadHours": "Look ahead hours",


### PR DESCRIPTION
As already discussed in #14:

Currently the node emits immediately on start. I think that this is usually not desirable. In fact for my use case surprising things happen as an unexpected message goes off somewhere in the middle of my flow. I had to add a special function node that filters the first message away. However this means unneeded traffic is created and it is not pretty either.

This PR makes this configurable.