### PR TITLE
Add tempc_min_next24h and tempc_max_next24h

### DIFF
--- a/dwdweather.html
+++ b/dwdweather.html
@@ -94,6 +94,8 @@
        <ul>
          <li><code>payload.station</code> - Description of the station location</li>
          <li><code>payload.tempc</code> - Temperature in °C</li>
+         <li><code>payload.tempc_min_next24h</code> - Minimal temperature in °C in next 24 hours</li>
+         <li><code>payload.tempc_max_next24h</code> - Maximum temperature in °C in next 24 hours</li>
          <li><code>payload.humidity</code> -  Relative humidity</li>
          <li><code>payload.windspeed</code> - Windspeed in m/s</li>
          <li><code>payload.winddirection</code> - Winddirection in °</li>

--- a/dwdweather.js
+++ b/dwdweather.js
@@ -147,6 +147,52 @@ module.exports = function(RED) {
         return sum;
     }
 
+    function maxFutureValue(mosmixStation, attribute, hours, forecastDate) {
+        var idx = getTimeIndex(mosmixStation, forecastDate);
+
+        assertAttributeExists(mosmixStation, attribute);
+
+        var max = NaN;
+        // find max value in x future values (x = hours), but not more than length of array
+        for (var i = idx; i < weatherForecast[mosmixStation][attribute].length && i < hours + idx; i++) {
+            var currentValue = weatherForecast[mosmixStation][attribute][i];
+
+            if (!isNaN(currentValue)) {
+                if (isNaN(max)) {
+                    max = currentValue;
+                } else {
+                    if (currentValue > max) {
+                        max = currentValue;
+                    }
+                }
+            }
+        }
+        return max;
+    }
+
+    function minFutureValue(mosmixStation, attribute, hours, forecastDate) {
+        var idx = getTimeIndex(mosmixStation, forecastDate);
+
+        assertAttributeExists(mosmixStation, attribute);
+
+        var min = NaN;
+        // find min value in x future values (x = hours), but not more than length of array
+        for (var i = idx; i < weatherForecast[mosmixStation][attribute].length && i < hours + idx; i++) {
+            var currentValue = weatherForecast[mosmixStation][attribute][i];
+
+            if (!isNaN(currentValue)) {
+                if (isNaN(min)) {
+                    min = currentValue;
+                } else {
+                    if (currentValue < min) {
+                        min = currentValue;
+                    }
+                }
+            }
+        }
+        return min;
+    }
+
     function getTimeIndex(mosmixStation, forecastDate) {
         if (!weatherForecast[mosmixStation]) {
             throw new Error(RED._("dwdweather.warn.noDataForStation"));
@@ -251,6 +297,8 @@ module.exports = function(RED) {
                         msg.payload = {
                             "station": weatherForecast[node.mosmixStation].description,
                             "tempc": getForecastedTemperature(node.mosmixStation, forecastDate),
+                            "tempc_min_next24h": Math.round(getTempCelsius(minFutureValue(node.mosmixStation, "TTT", 24, forecastDate)) * 10) / 10,
+                            "tempc_max_next24h": Math.round(getTempCelsius(maxFutureValue(node.mosmixStation, "TTT", 24, forecastDate)) * 10) / 10,
                             "humidity": getForecastedHumidity(node.mosmixStation, forecastDate),
                             "windspeed": Math.round(getInterpolatedValue(node.mosmixStation, "FF", forecastDate) * 10) / 10,
                             "winddirection": Math.round(getInterpolatedValue(node.mosmixStation, "DD", forecastDate) * 10) / 10,

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,8 @@ A node red node that returns German DWD MOSMIX current / forecasted weather for 
 
 It gives you the following data:
 - Temperature in °C (in a 2 m height)
+- Minimal temperature in °C (in a 2 m height) in the next 24 hours
+- Maximum temperature in °C (in a 2 m height) in the next 24 hours
 - Relative humidity in %
 - Windspeed in m/s (in a 10 m height)
 - Wind direction in degrees
@@ -113,6 +115,8 @@ The following figure shows the `msg.payload` structure of an example with "FF,FX
 ##### MOSMIX elements used by the node
 The following MOSMIX elements are used as the basis for the node's `msg.payload` values:
 - `payload.tempc`:  "TTT"
+- `payload.tempc_min_next24h`:  "TTT"
+- `payload.tempc_max_next24h`:  "TTT"
 - `payload.humidity`: "Td" and "TTT"
 - `payload.windspeed`: "FF"
 - `payload.winddirection`: "DD"
@@ -136,6 +140,8 @@ The node emits a `msg` whenever it is triggered by an input `msg` or at the conf
 The default `msg` attributes are:
 * `payload.station` - Description (location) of the station
 * `payload.tempc` - Temperature in °C
+* `payload.tempc_min_next24h` - Minimal temperature in °C in next 24 hours
+* `payload.tempc_max_next24h` - Maximun temperature in °C in next 24 hours
 * `payload.humidity` -  Relative humidity
 * `payload.windspeed` - Windspeed in m/s
 * `payload.winddirection` - Winddirection in °


### PR DESCRIPTION
Add default output values: tempc_min_next24h and tempc_max_next24h to have easily available min/max values forecasted.