### PR TITLE
fix: undefined msg.payload leads to an error message: MOSMIX request …

### DIFF
--- a/dwdweather.js
+++ b/dwdweather.js
@@ -238,6 +238,7 @@ module.exports = function(RED) {
         }
 
         node.on('input', function(msg) {
+            msg.payload ??= {};
             updateWeatherForecastIfOutdated(node)
             .then(() => {
                 if (weatherForecast[node.mosmixStation]) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-dwd-local-weather",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Node Red node to retrieve local weather forecast from DWD (Germany)",
   "main": "index.js",
   "homepage": "https://github.com/c5te1n/node-red-contrib-dwd-local-weather",


### PR DESCRIPTION
…failed: TypeError: Cannot read properties of undefined (reading 'lookAheadHours')

fixes: #49 